### PR TITLE
“原始JSON全息告示牌在在线玩家开启了Realm聊天过滤时无法渲染精灵图组件“的简单修复

### DIFF
--- a/src/main/java/org/teacon/powertool/block/entity/RawJsonHolographicSignBlockEntity.java
+++ b/src/main/java/org/teacon/powertool/block/entity/RawJsonHolographicSignBlockEntity.java
@@ -75,13 +75,21 @@ public class RawJsonHolographicSignBlockEntity extends BaseHolographicSignBlockE
         var taskList = new ArrayList<CompletableFuture<?>>();
         //不用processMessageBundle 因为没有处理后list size和顺序不变的保证
         for (var i = 0; i < forFilter.size(); i++) {
-            
+            // In vanilla, only /say, /msg, /me, /teammsg, item name editing, book content editing, and sign editing
+            // will have text filter applied, and for all of those, player can only edit them with plain text.
+            // In our case, however, involves raw json which will be much more complicated.
+            // If we handle them component by component, this filtering can be easily attacked when the player break
+            // an illegal word into siblings of components.
+            // If we stringify the component, we will lose the arguments of more complex component and can hardly,
+            // if not never, recover the component tree.
+            // For simplicity, we return the original component if the filtering will not mask anything,
+            // and construct a literal component if, unfortunately, something will be masked out.
             var task = player.getTextFilter()
                     .processStreamMessage(forFilter.get(i).getString());
             int finalI = i;
             task.thenAccept(filtered -> {
                 if (player.isTextFilteringEnabled()) {
-                    this.forRender.add(finalI, Component.literal(filtered.filteredOrEmpty()).withStyle(forFilter.get(finalI).getStyle()));
+                    this.forRender.add(finalI, !filtered.isFiltered() ? forFilter.get(finalI) : Component.literal(filtered.filteredOrEmpty()).withStyle(forFilter.get(finalI).getStyle()));
                 } else {
                     this.forRender.add(finalI, forFilter.get(finalI));
                 }


### PR DESCRIPTION
当服务器接收到原始JSON全息告示牌的内容更新包时，会尝试参照原版去对文本内容执行聊天过滤。然而，原版的聊天过滤是针对纯文本而非文本组件设计的，使得PowerTool执行这个步骤时得先将文本组件转为纯文本，结果破坏了精灵图文本组件，使得精灵图组件总是渲染成了fallback。
这个PR只是简单的在过滤器实际上没有过滤任何东西时返回原本的文本组件，考虑到如果按每一个组件去做过滤，玩家完全可以这样去绕过：
`{"extra":[{"text":"mother"}, {"text":"fu"}, {"text":"c"}, {"text":"ke"}, {"text":"r"}]}`